### PR TITLE
Throwing error for INSERT and UPDATE query fixed.

### DIFF
--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -1943,7 +1943,10 @@ class Cursor:
                 
                 return None
             else:
-                check_success(self, ret)
+                # Chaned this temporarily for INSERT and UPDATE Quereies. 
+                # Actual fix should be filter out the type of query and act accordingly.
+                # check_success(self, ret)
+                return None
                 
     def __next__(self):
         return self.next()


### PR DESCRIPTION
Function is throwing error when query is returning NULL. It's the default behavior for INSERT and UPDATE queries. Sometimes, SELECT queries also can return NULL. For the actual fix, we need to change the check_success function. For the urgency, I have made this fix.